### PR TITLE
Change owslib version to >=0.25.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python: ["3.6", "3.8"]
+        python: ["3.10"]
     runs-on: ubuntu-22.04
     container: "python:${{matrix.python}}-slim-buster"
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.6", "3.8"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: "python:${{matrix.python}}-slim-buster"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,7 +82,8 @@ jobs:
           python-version: "3.5"
 
       - name: Install GDAL
-        run: sudo apt-get install -y gdal-bin
+        run: sudo apt-get update && sudo apt-get install -y gdal-bin
+
         if: ${{ matrix.toxenv == 'sanitizer' }}
 
       - name: Install Tox and tox-gh-actions

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python: ["3.5", "3.6", "3.8"]
+        python: ["3.6", "3.8"]
     runs-on: ubuntu-20.04
     container: "python:${{matrix.python}}-slim-buster"
     steps:

--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,7 @@ drf-jwt-2fa
 lxml
 
 # WFS
-owslib
+owslib>=0.25.0
 
 # Misc
 django-cors-headers

--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,7 @@ drf-jwt-2fa
 lxml
 
 # WFS
-owslib>=0.25.0
+owslib==0.25.0
 
 # Misc
 django-cors-headers

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 database-sanitizer==1.1.0  # via django-sanitized-dump
-dataclasses==0.8          # via owslib
 django==2.2.15
 django-cors-headers==3.5.0
 django-environ==0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 database-sanitizer==1.1.0  # via django-sanitized-dump
+dataclasses==0.8          # via owslib
 django==2.2.15
 django-cors-headers==3.5.0
 django-environ==0.4.5
@@ -18,14 +19,13 @@ djangorestframework-jwt==1.11.0  # via drf-jwt-2fa
 drf-jwt-2fa==0.3.0
 idna==2.10                # via requests
 lxml==4.5.2
-owslib==0.19.1
+owslib==0.29.3
 psycopg2==2.8.5
 pyjwt==1.7.1              # via djangorestframework-jwt
-pyproj==2.6.1.post1       # via owslib
 python-dateutil==2.8.1    # via owslib
 python-memcached==1.59
 pytz==2020.1
-pyyaml==5.3.1             # via database-sanitizer, django-sanitized-dump
+pyyaml==5.3.1             # via database-sanitizer, django-sanitized-dump, owslib
 raven==6.10.0
 requests==2.24.0          # via owslib
 six==1.15.0               # via database-sanitizer, django-sanitized-dump, python-dateutil, python-memcached

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,13 +18,14 @@ djangorestframework-jwt==1.11.0  # via drf-jwt-2fa
 drf-jwt-2fa==0.3.0
 idna==2.10                # via requests
 lxml==4.5.2
-owslib==0.29.3
+owslib==0.25.0
 psycopg2==2.8.5
 pyjwt==1.7.1              # via djangorestframework-jwt
 python-dateutil==2.8.1    # via owslib
 python-memcached==1.59
 pytz==2020.1
-pyyaml==5.3.1             # via database-sanitizer, django-sanitized-dump, owslib
+pyproj==3.3.0             # via owslib
+pyyaml==5.4.1             # via database-sanitizer, django-sanitized-dump, ows
 raven==6.10.0
 requests==2.24.0          # via owslib
 six==1.15.0               # via database-sanitizer, django-sanitized-dump, python-dateutil, python-memcached


### PR DESCRIPTION
Required by Ubuntu 22.04

# Change owslib version to =0.25.0
## Description
Required by Ubuntu 22.04

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Requirements
  1. requirements.in
     * Change owslib version to >=0.25.0
  2. requirements.txt
      *Change owslib version to >=0.25.0
 
