### PR TITLE
Feature/enforcement api check parking add details parameter

### DIFF
--- a/docs/api/enforcement.yaml
+++ b/docs/api/enforcement.yaml
@@ -386,6 +386,16 @@ paths:
                     given, defaults to current time.
                   type: string
                   format: date-time
+                details:
+                  description: >-
+                    Optional additional details. Takes as argument a list of preferred details.
+                    The details are: operator, time_start and permissions.
+                  type: array
+                  items:
+                    type: string
+                  default: []
+                  example: ["operator", "time_start", "permissions"]
+
       responses:
         '200':
           description: OK. Validity check succeeded.
@@ -454,11 +464,53 @@ paths:
                         nullable: true
                   time:
                     description: >-
-                      Time used in the check.  It will either be equal
+                      Time used in the check. It will either be equal
                       to the time value provided in the request or the
                       current time if none was provided.
                     type: string
                     format: date-time
+                  operator:
+                    description: >-
+                      If 'operator' in details, returns the operator
+                      of the allowed parking.
+                    type: string
+                    nullable: true
+                  time_start:
+                    description: >-
+                      If 'time_start' in details, returns the time_start
+                      of the allowed parking.
+                    type: string
+                    format: date-time
+                    nullable: true
+                  permissions:
+                    description: >-
+                      If 'permissions' in details, returns the active permissions
+                       for the registration number.
+                    type: object
+                    properties:
+                      event_areas:
+                        description: >-
+                          List of event area IDs to which the registration number has permissions.
+                        type: array
+                        items:
+                          type: string
+                      zones:
+                        description: List of zones to which the registration number has permissions.
+                        type: array
+                        items:
+                          type: integer
+                      permits:
+                        description: List of active permits for the registration number.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            external_id:
+                              type: string
+                            subjects: &permitSubjects
+                              $ref: '#/components/schemas/PermitSubjects'
+                            targets: &permitAreas
+                                $ref: '#/components/schemas/PermitAreas'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':

--- a/parkings/api/enforcement/check_parking.py
+++ b/parkings/api/enforcement/check_parking.py
@@ -122,7 +122,7 @@ class CheckParking(generics.GenericAPIView):
                 "permits": [
                     PermitPermissionsSerializer(item.permit).data for item in permit_lookup_items
                 ],
-                "event_areas": list({e_p.event_area.origin_id for e_p in active_event_parkings})
+                "event_areas": list({e_p.event_area.id for e_p in active_event_parkings})
             }
 
         filter = {

--- a/parkings/api/enforcement/check_parking.py
+++ b/parkings/api/enforcement/check_parking.py
@@ -99,10 +99,10 @@ class CheckParking(generics.GenericAPIView):
         operator_detail, time_start_detail, permissions_detail = get_details(params)
 
         if operator_detail:
-            result["operator"] = parking.operator.name if parking and parking.operator else None
+            result["operator"] = parking.operator.name if allowed and parking and parking.operator else None
 
         if time_start_detail:
-            result["time_start"] = parking.time_start if parking and parking.time_start else None
+            result["time_start"] = parking.time_start if allowed and parking and parking.time_start else None
 
         if permissions_detail:
             if isinstance(parking, EventParking):
@@ -225,8 +225,9 @@ def check_parking(registration_number, zone, area, time, domain, event_area):
 
     for parking in active_parkings:
         if parking.zone.number > zone:
-            return (None, parking, parking.time_end, permit_lookup_item_qs)
+            return (None, parking, None, permit_lookup_item_qs)
 
+    # move up
     active_event_parking = (
         EventParking.objects
         .registration_number_like(registration_number)

--- a/parkings/api/enforcement/check_parking.py
+++ b/parkings/api/enforcement/check_parking.py
@@ -118,15 +118,11 @@ class CheckParking(generics.GenericAPIView):
 
         if permissions_detail:
             result["permissions"] = {
-                "zones": [
-                    p.zone.number for p in active_parkings
-                ],
+                "zones": list({p.zone.number for p in active_parkings}),
                 "permits": [
                     PermitPermissionsSerializer(item.permit).data for item in permit_lookup_items
                 ],
-                "event_areas": [
-                    e_p.event_area.origin_id for e_p in active_event_parkings
-                ]
+                "event_areas": list({e_p.event_area.origin_id for e_p in active_event_parkings})
             }
 
         filter = {

--- a/parkings/tests/api/enforcement/test_check_parking.py
+++ b/parkings/tests/api/enforcement/test_check_parking.py
@@ -125,7 +125,7 @@ def test_check_parking_allowed_event_parking_details(
     assert response.status_code == HTTP_200_OK
     assert response.data["allowed"] is True
     assert response.data["end_time"] == event_parking.time_end
-    assert response.data["permissions"]["event_area"] == event_area.origin_id
+    assert response.data["permissions"]["event_areas"][0] == event_area.origin_id
     assert response.data["operator"] == event_parking.operator.name
     assert response.data["time_start"] == event_parking.time_start
     assert ParkingCheck.objects.filter(
@@ -143,7 +143,7 @@ def test_check_parking_not_allowed_event_parking_details(
     assert response.status_code == HTTP_200_OK
     assert response.data["allowed"] is False
     assert response.data["end_time"] is None
-    assert response.data["permissions"]["event_area"] is None
+    assert response.data["permissions"]["event_areas"] == []
     assert response.data["permissions"]["zone"] is None
     assert response.data["operator"] is None
     assert response.data["time_start"] is None
@@ -167,7 +167,8 @@ def test_check_event_parking_parked_in_wrong_event_area_include_details(
     assert response.data["location"]["event_area"] == event_area_2.id
     assert response.data["allowed"] is False
     assert response.data["end_time"] is None
-    assert response.data["permissions"]["event_area"] == event_area_1.origin_id
+    assert len(response.data["permissions"]["event_areas"]) == 1
+    assert event_area_1.origin_id in response.data["permissions"]["event_areas"]
     assert response.data["permissions"]["zone"] is None
     assert response.data["operator"] is None
     assert response.data["time_start"] is None
@@ -259,7 +260,7 @@ def test_check_parking_details_permissions_parameter(operator, enforcer, enforce
 
     assert response.status_code == HTTP_200_OK
     assert response.data["permissions"]["zone"] == parking.zone.number
-    assert response.data["permissions"]["event_area"] is None
+    assert response.data["permissions"]["event_areas"] == []
     assert response.data["allowed"] is True
     assert response.data["end_time"] == parking.time_end
 
@@ -336,7 +337,7 @@ def test_check_parking_valid_parking_permit_details(enforcer_api_client, staff_u
     assert response.data["operator"] is None
     assert response.data["time_start"] is None
     assert response.data["permissions"]["zone"] is None
-    assert response.data["permissions"]["event_area"] is None
+    assert response.data["permissions"]["event_areas"] == []
     assert len(response.data["permissions"]["permits"]) == 1
     assert response.data["permissions"]["permits"][0]["subjects"] == permit.subjects
     assert response.data["permissions"]["permits"][0]["areas"] == permit.areas

--- a/parkings/tests/api/enforcement/test_check_parking.py
+++ b/parkings/tests/api/enforcement/test_check_parking.py
@@ -132,7 +132,7 @@ def test_check_parking_allowed_event_parking_details(
     assert response.status_code == HTTP_200_OK
     assert response.data["allowed"] is True
     assert response.data["end_time"] == event_parking.time_end
-    assert response.data["permissions"]["event_areas"][0] == event_area.origin_id
+    assert response.data["permissions"]["event_areas"][0] == event_area.id
     assert response.data["operator"] == event_parking.operator.name
     assert response.data["time_start"] == event_parking.time_start
     assert ParkingCheck.objects.filter(
@@ -175,7 +175,7 @@ def test_check_event_parking_parked_in_wrong_event_area_include_details(
     assert response.data["allowed"] is False
     assert response.data["end_time"] is None
     assert len(response.data["permissions"]["event_areas"]) == 1
-    assert event_area_1.origin_id in response.data["permissions"]["event_areas"]
+    assert event_area_1.id in response.data["permissions"]["event_areas"]
     assert response.data["permissions"]["zones"] == []
     assert response.data["operator"] is None
     assert response.data["time_start"] is None
@@ -199,10 +199,12 @@ def test_check_parking_not_allowed_parking_and_event_parking_permission_details(
 
     assert response.status_code == HTTP_200_OK
     assert response.data["allowed"] is False
-    assert response.data["permissions"]["event_areas"] == [event_area.origin_id]
+    assert response.data["permissions"]["event_areas"] == [event_area.id]
     assert response.data["permissions"]["zones"] == [parking.zone.number]
     assert response.data["operator"] is None
     assert response.data["time_start"] is None
+    assert ParkingCheck.objects.filter(
+        registration_number=PARKING_DATA["registration_number"]).first().result["allowed"] is False
 
 
 def test_check_parking_not_allowed_multiple_active_parkings_and_permits_permissions_details(
@@ -245,8 +247,8 @@ def test_check_parking_not_allowed_multiple_active_parkings_and_permits_permissi
     assert response.data["allowed"] is False
     assert response.data["location"]["payment_zone"] == zone_1.number
     assert len(response.data["permissions"]["event_areas"]) == 2
-    assert event_area_1.origin_id in response.data["permissions"]["event_areas"]
-    assert event_area_2.origin_id in response.data["permissions"]["event_areas"]
+    assert event_area_1.id in response.data["permissions"]["event_areas"]
+    assert event_area_2.id in response.data["permissions"]["event_areas"]
     assert len(response.data["permissions"]["zones"]) == 2
     assert zone_2.number in response.data["permissions"]["zones"]
     assert zone_3.number in response.data["permissions"]["zones"]
@@ -257,6 +259,8 @@ def test_check_parking_not_allowed_multiple_active_parkings_and_permits_permissi
     assert response.data["permissions"]["permits"][1]["areas"] == permit_2.areas
     assert response.data["operator"] is None
     assert response.data["time_start"] is None
+    assert ParkingCheck.objects.filter(
+        registration_number=PARKING_DATA["registration_number"]).first().result["allowed"] is False
 
 
 def test_check_event_parking_outside_event_area(
@@ -319,6 +323,8 @@ def test_check_parking_details_operator_parameter(operator, enforcer, enforcer_a
     assert response.data["operator"] == operator.name
     assert response.data["allowed"] is True
     assert response.data["end_time"] == parking.time_end
+    assert ParkingCheck.objects.filter(
+        registration_number=PARKING_DATA["registration_number"]).first().result["allowed"] is True
 
 
 def test_check_parking_details_time_start_parameter(operator, enforcer, enforcer_api_client, parking_factory):
@@ -332,6 +338,8 @@ def test_check_parking_details_time_start_parameter(operator, enforcer, enforcer
     assert response.data["time_start"] == parking.time_start
     assert response.data["allowed"] is True
     assert response.data["end_time"] == parking.time_end
+    assert ParkingCheck.objects.filter(
+        registration_number=PARKING_DATA["registration_number"]).first().result["allowed"] is True
 
 
 def test_check_parking_details_permissions_parameter(operator, enforcer, enforcer_api_client, parking_factory):
@@ -358,6 +366,8 @@ def test_check_parking_details_parking_not_allowed(operator, enforcer, enforcer_
     assert response.data["operator"] is None
     assert response.data["time_start"] is None
     assert response.data["permissions"]["zones"] == []
+    assert ParkingCheck.objects.filter(
+        registration_number=PARKING_DATA["registration_number"]).first().result["allowed"] is False
 
 
 def test_check_parking_details_invalid_zone(operator, enforcer, enforcer_api_client, parking_factory):
@@ -424,6 +434,8 @@ def test_check_parking_valid_parking_permit_details(enforcer_api_client, staff_u
     assert len(response.data["permissions"]["permits"]) == 1
     assert response.data["permissions"]["permits"][0]["subjects"] == permit.subjects
     assert response.data["permissions"]["permits"][0]["areas"] == permit.areas
+    assert ParkingCheck.objects.filter(
+        registration_number=PARKING_DATA["registration_number"]).first().result["allowed"] is True
 
 
 def test_check_parking_invalid_location_multiple_permit_details(enforcer_api_client, staff_user):
@@ -445,6 +457,8 @@ def test_check_parking_invalid_location_multiple_permit_details(enforcer_api_cli
     assert response.data["permissions"]["permits"][0]["areas"] == permit_1.areas
     assert response.data["permissions"]["permits"][1]["subjects"] == permit_2.subjects
     assert response.data["permissions"]["permits"][1]["areas"] == permit_2.areas
+    assert ParkingCheck.objects.filter(
+        registration_number=PARKING_DATA["registration_number"]).first().result["allowed"] is False
 
 
 def test_check_parking_valid_parking_with_permit_details(enforcer_api_client, parking_factory, operator):
@@ -466,6 +480,8 @@ def test_check_parking_valid_parking_with_permit_details(enforcer_api_client, pa
     assert response.data["permissions"]["zones"] == [parking.zone.number]
     assert response.data["time_start"] == parking.time_start
     assert response.data["operator"] == parking.operator.name
+    assert ParkingCheck.objects.filter(
+        registration_number=PARKING_DATA["registration_number"]).first().result["allowed"] is True
 
 
 def test_check_parking_invalid_time_permit(enforcer_api_client, staff_user):

--- a/parkings/tests/api/enforcement/test_check_parking.py
+++ b/parkings/tests/api/enforcement/test_check_parking.py
@@ -166,7 +166,7 @@ def test_check_event_parking_parked_in_wrong_event_area_include_details(
     assert response.status_code == HTTP_200_OK
     assert response.data["location"]["event_area"] == event_area_2.id
     assert response.data["allowed"] is False
-    assert response.data["end_time"] == event_parking.time_end
+    assert response.data["end_time"] is None
     assert response.data["permissions"]["event_area"] == event_area_1.origin_id
     assert response.data["permissions"]["zone"] is None
     assert response.data["operator"] == event_parking.operator.name
@@ -179,13 +179,13 @@ def test_check_event_parking_outside_event_area(
         enforcer_api_client, event_parking_factory, enforcer, event_area_factory):
     event_area = event_area_factory.create(geom=create_area_geom(), domain=enforcer.enforced_domain)
     location = Point(PARKING_DATA_2["location"]["longitude"], PARKING_DATA_2["location"]["latitude"], srid=WGS84_SRID)
-    event_parking = event_parking_factory(registration_number="ABC-123",
-                                          domain=enforcer.enforced_domain, event_area=event_area, location=location)
+    event_parking_factory(registration_number="ABC-123",
+                          domain=enforcer.enforced_domain, event_area=event_area, location=location)
     response = enforcer_api_client.post(list_url, data=PARKING_DATA_2)
     assert response.status_code == HTTP_200_OK
     assert response.data["location"]["event_area"] is None
     assert response.data["allowed"] is False
-    assert response.data["end_time"] == event_parking.time_end
+    assert response.data["end_time"] is None
     assert ParkingCheck.objects.filter(
         registration_number=PARKING_DATA["registration_number"]).first().result["allowed"] is False
 


### PR DESCRIPTION
# Add details parameter to enforcement API

## Description
 Returns operator, time_start for allowed parking and all permission for the registration number in check_parking endpoint.
[Trello](https://trello.com/c/9IuRSyDb)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed 
1. docs/api/enforcement.yaml
    * Add information about details parameter.
2. parkings/api/enforcement/check_parking.py
    * Add details parameter, that returns time_start, operator of the allowed parking and all the permission for the registration number.
3. parkings/tests/api/enforcement/test_check_parking.py
    * Test details parameter.
